### PR TITLE
 data refs

### DIFF
--- a/config/tsconfig.json
+++ b/config/tsconfig.json
@@ -15,13 +15,10 @@
     ],
     "module": "es6",
     "moduleResolution": "node",
-    "noImplicitAny": true,
     "noImplicitReturns": true,
-    "noImplicitThis": true,
     "outDir": "../out",
     "sourceMap": true,
     "strict": true,
-    "strictNullChecks": true,
     "target": "es2017",
     "types": [
       "jsonpath-plus",

--- a/rules/tsconfig.yml
+++ b/rules/tsconfig.yml
@@ -33,6 +33,7 @@ rules:
     check:
       not:
         anyOf:
+          # from https://www.typescriptlang.org/docs/handbook/compiler-options.html
           - required: [alwaysStrict]
           - required: [noImplicitAny]
           - required: [noImplicitThis]
@@ -75,47 +76,8 @@ rules:
                 lib:
                   contains:
                     type: string
-                    const: esnext
+                    const:
+                      $data: "2/target"
                 target:
                   type: string
-                  const: esnext
-            - properties:
-                lib:
-                  contains:
-                    type: string
-                    const: es2017
-                target:
-                  type: string
-                  const: es2017
-            - properties:
-                lib:
-                  contains:
-                    type: string
-                    const: es2016
-                target:
-                  type: string
-                  const: es2016
-            - properties:
-                lib:
-                  contains:
-                    type: string
-                    enum: [es2015, es6]
-                target:
-                  type: string
-                  enum: [es2015, es6]
-            - properties:
-                lib:
-                  contains:
-                    type: string
-                    const: es5
-                target:
-                  type: string
-                  const: es5
-            - properties:
-                lib:
-                  contains:
-                    type: string
-                    const: es3
-                target:
-                  type: string
-                  const: es3
+                  enum: [esnext, es2017, es2016, es5, es3]

--- a/src/visitor/VisitorContext.ts
+++ b/src/visitor/VisitorContext.ts
@@ -36,6 +36,7 @@ export class VisitorContext implements VisitorContextOptions, VisitorResult {
     this.errorBuffer = [];
 
     this.ajv = new Ajv({
+      $data: true,
       coerceTypes: options.innerOptions.coerce,
       useDefaults: options.innerOptions.defaults,
     });


### PR DESCRIPTION
Enable https://ajv.js.org/#data-reference and use it to flatten the tsconfig lib/target rules.

- fixes #22 