### PR TITLE
fix(config): bundle yargs module again

### DIFF
--- a/config/rollup.js
+++ b/config/rollup.js
@@ -1,10 +1,11 @@
+import alias from '@rollup/plugin-alias';
+import commonjs from '@rollup/plugin-commonjs';
+import resolve from '@rollup/plugin-node-resolve';
 import { join, sep } from 'path';
-import commonjs from 'rollup-plugin-commonjs';
 import { eslint } from 'rollup-plugin-eslint';
 import json from 'rollup-plugin-json';
 import multiEntry from 'rollup-plugin-multi-entry';
 import externals from 'rollup-plugin-node-externals';
-import resolve from 'rollup-plugin-node-resolve';
 import replace from 'rollup-plugin-replace';
 import typescript from 'rollup-plugin-typescript2';
 import yaml from 'rollup-plugin-yaml';
@@ -72,6 +73,11 @@ const bundle = {
 		multiEntry(),
 		json(),
 		yaml(),
+    alias({
+      entries: {
+        'yargs': './node_modules/yargs/index.cjs'
+      },
+    }),
 		externals({
 			builtins: true,
 			deps: true,

--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
     "@istanbuljs/nyc-config-typescript": "1.0.1",
     "@microsoft/api-documenter": "7.12.16",
     "@microsoft/api-extractor": "7.13.2",
+    "@rollup/plugin-alias": "^3.1.2",
+    "@rollup/plugin-commonjs": "^18.0.0",
+    "@rollup/plugin-node-resolve": "^11.2.1",
     "@types/bunyan": "1.8.6",
     "@types/chai": "4.2.15",
     "@types/chai-as-promised": "7.1.3",
@@ -96,9 +99,7 @@
     "tslint-clean-code": "0.2.10",
     "tslint-microsoft-contrib": "6.2.0",
     "tslint-sonarts": "1.9.0",
-    "typescript": "4.2.3"
-  },
-  "dependencies": {
+    "typescript": "4.2.3",
     "yargs": "16.2.0"
   },
   "nyc": {

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,5 @@
 import { createLogger } from 'bunyan';
+import { showCompletionScript } from 'yargs';
 
 import { loadConfig } from './config';
 import { CONFIG_ARGS_NAME, CONFIG_ARGS_PATH, MODE, parseArgs } from './config/args';
@@ -9,9 +10,6 @@ import { readSource, writeSource } from './source';
 import { VERSION_INFO } from './version';
 import { VisitorContext } from './visitor/VisitorContext';
 
-/* eslint-disable-next-line @typescript-eslint/no-var-requires */
-const yargs = require('yargs');
-
 const ARGS_START = 2;
 export const STATUS_SUCCESS = 0;
 export const STATUS_ERROR = 1;
@@ -20,7 +18,7 @@ export const STATUS_MAX = 255;
 export async function main(argv: Array<string>): Promise<number> {
   const { args, mode } = await parseArgs(argv.slice(ARGS_START));
   if (mode === MODE.complete) {
-    yargs.showCompletionScript();
+    showCompletionScript();
     return STATUS_SUCCESS;
   }
 

--- a/src/config/args.ts
+++ b/src/config/args.ts
@@ -1,8 +1,7 @@
+import { Options, usage } from 'yargs';
+
 import { RuleSelector, RuleSources } from '../rule';
 import { VERSION_INFO } from '../version';
-
-/* eslint-disable-next-line @typescript-eslint/no-var-requires */
-const yargs = require('yargs');
 
 export enum MODE {
   check = 'check',
@@ -16,7 +15,7 @@ export enum MODE {
 export const CONFIG_ARGS_NAME = 'config-name';
 export const CONFIG_ARGS_PATH = 'config-path';
 
-const RULE_OPTION = {
+const RULE_OPTION: Options = {
   default: [],
   group: 'Rules:',
   type: 'array',
@@ -50,7 +49,7 @@ export interface ParseResults {
 export async function parseArgs(argv: Array<string>): Promise<ParseResults> {
   let mode: MODE = MODE.check;
 
-  const parser = yargs.usage('Usage: salty-dog <mode> [options]')
+  const parser = usage('Usage: salty-dog <mode> [options]')
     .command({
       command: ['check', '*'],
       describe: 'validate the source documents',

--- a/yarn.lock
+++ b/yarn.lock
@@ -250,6 +250,47 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
+"@rollup/plugin-alias@^3.1.2":
+  version "3.1.2"
+  resolved "https://artifacts.apextoaster.com/repository/group-npm/@rollup/plugin-alias/-/plugin-alias-3.1.2.tgz#c585b05be4a7782d269c69d13def56f44e417772"
+  integrity sha512-wzDnQ6v7CcoRzS0qVwFPrFdYA4Qlr+ookA217Y2Z3DPZE1R8jrFNM3jvGgOf6o6DMjbnQIn5lCIJgHPe1Bt3uw==
+  dependencies:
+    slash "^3.0.0"
+
+"@rollup/plugin-commonjs@^18.0.0":
+  version "18.0.0"
+  resolved "https://artifacts.apextoaster.com/repository/group-npm/@rollup/plugin-commonjs/-/plugin-commonjs-18.0.0.tgz#50dc7518b5aa9e66a270e529ea85115d269825c4"
+  integrity sha512-fj92shhg8luw7XbA0HowAqz90oo7qtLGwqTKbyZ8pmOyH8ui5e+u0wPEgeHLH3djcVma6gUCUrjY6w5R2o1u6g==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    commondir "^1.0.1"
+    estree-walker "^2.0.1"
+    glob "^7.1.6"
+    is-reference "^1.2.1"
+    magic-string "^0.25.7"
+    resolve "^1.17.0"
+
+"@rollup/plugin-node-resolve@^11.2.1":
+  version "11.2.1"
+  resolved "https://artifacts.apextoaster.com/repository/group-npm/@rollup/plugin-node-resolve/-/plugin-node-resolve-11.2.1.tgz#82aa59397a29cd4e13248b106e6a4a1880362a60"
+  integrity sha512-yc2n43jcqVyGE2sqV5/YCmocy9ArjVAP/BeXyTtADTBBX6V0e5UMqwO8CdQ0kzjb6zu5P1qMzsScCMRvE9OlVg==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    "@types/resolve" "1.17.1"
+    builtin-modules "^3.1.0"
+    deepmerge "^4.2.2"
+    is-module "^1.0.0"
+    resolve "^1.19.0"
+
+"@rollup/pluginutils@^3.1.0":
+  version "3.1.0"
+  resolved "https://artifacts.apextoaster.com/repository/group-npm/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"
+  integrity sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==
+  dependencies:
+    "@types/estree" "0.0.39"
+    estree-walker "^1.0.1"
+    picomatch "^2.2.2"
+
 "@rollup/pluginutils@^4.1.0":
   version "4.1.0"
   resolved "https://artifacts.apextoaster.com/repository/group-npm/@rollup/pluginutils/-/pluginutils-4.1.0.tgz#0dcc61c780e39257554feb7f77207dceca13c838"
@@ -372,6 +413,11 @@
   resolved "https://artifacts.apextoaster.com/repository/group-npm/@types/deep-diff/-/deep-diff-1.0.0.tgz#7eba3202a99b3a207f758f351f7f86387269fc40"
   integrity sha512-ENsJcujGbCU/oXhDfQ12mSo/mCBWodT2tpARZKmatoSrf8+cGRCPi0KVj3I0FORhYZfLXkewXu7AoIWqiBLkNw==
 
+"@types/estree@*":
+  version "0.0.47"
+  resolved "https://artifacts.apextoaster.com/repository/group-npm/@types/estree/-/estree-0.0.47.tgz#d7a51db20f0650efec24cd04994f523d93172ed4"
+  integrity sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg==
+
 "@types/estree@0.0.39":
   version "0.0.39"
   resolved "https://artifacts.apextoaster.com/repository/group-npm/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
@@ -445,6 +491,13 @@
   version "0.0.8"
   resolved "https://artifacts.apextoaster.com/repository/group-npm/@types/resolve/-/resolve-0.0.8.tgz#f26074d238e02659e323ce1a13d041eee280e194"
   integrity sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
+  dependencies:
+    "@types/node" "*"
+
+"@types/resolve@1.17.1":
+  version "1.17.1"
+  resolved "https://artifacts.apextoaster.com/repository/group-npm/@types/resolve/-/resolve-1.17.1.tgz#3afd6ad8967c77e4376c598a82ddd58f46ec45d6"
+  integrity sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==
   dependencies:
     "@types/node" "*"
 
@@ -1344,6 +1397,11 @@ deep-is@^0.1.3, deep-is@~0.1.3:
   resolved "https://artifacts.apextoaster.com/repository/group-npm/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
+deepmerge@^4.2.2:
+  version "4.2.2"
+  resolved "https://artifacts.apextoaster.com/repository/group-npm/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
+  integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
+
 default-require-extensions@^3.0.0:
   version "3.0.0"
   resolved "https://artifacts.apextoaster.com/repository/group-npm/default-require-extensions/-/default-require-extensions-3.0.0.tgz#e03f93aac9b2b6443fc52e5e4a37b3ad9ad8df96"
@@ -1768,6 +1826,11 @@ estree-walker@^0.6.1:
   version "0.6.1"
   resolved "https://artifacts.apextoaster.com/repository/group-npm/estree-walker/-/estree-walker-0.6.1.tgz#53049143f40c6eb918b23671d1fe3219f3a1b362"
   integrity sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==
+
+estree-walker@^1.0.1:
+  version "1.0.1"
+  resolved "https://artifacts.apextoaster.com/repository/group-npm/estree-walker/-/estree-walker-1.0.1.tgz#31bc5d612c96b704106b477e6dd5d8aa138cb700"
+  integrity sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==
 
 estree-walker@^2.0.1:
   version "2.0.2"
@@ -2495,6 +2558,13 @@ is-reference@^1.1.2:
   dependencies:
     "@types/estree" "0.0.39"
 
+is-reference@^1.2.1:
+  version "1.2.1"
+  resolved "https://artifacts.apextoaster.com/repository/group-npm/is-reference/-/is-reference-1.2.1.tgz#8b2dac0b371f4bc994fdeaba9eb542d03002d0b7"
+  integrity sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==
+  dependencies:
+    "@types/estree" "*"
+
 is-regex@^1.1.0:
   version "1.1.0"
   resolved "https://artifacts.apextoaster.com/repository/group-npm/is-regex/-/is-regex-1.1.0.tgz#ece38e389e490df0dc21caea2bd596f987f767ff"
@@ -2874,6 +2944,13 @@ magic-string@^0.25.2:
   version "0.25.3"
   resolved "https://artifacts.apextoaster.com/repository/group-npm/magic-string/-/magic-string-0.25.3.tgz#34b8d2a2c7fec9d9bdf9929a3fd81d271ef35be9"
   integrity sha512-6QK0OpF/phMz0Q2AxILkX2mFhi7m+WMwTRg0LQKq/WBB0cDP4rYH3Wp4/d3OTXlrPLVJT/RFqj8tFeAR4nk8AA==
+  dependencies:
+    sourcemap-codec "^1.4.4"
+
+magic-string@^0.25.7:
+  version "0.25.7"
+  resolved "https://artifacts.apextoaster.com/repository/group-npm/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
+  integrity sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==
   dependencies:
     sourcemap-codec "^1.4.4"
 
@@ -3807,7 +3884,7 @@ resolve-from@^5.0.0:
   resolved "https://artifacts.apextoaster.com/repository/group-npm/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
-resolve@1.20.0:
+resolve@1.20.0, resolve@^1.19.0:
   version "1.20.0"
   resolved "https://artifacts.apextoaster.com/repository/group-npm/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
   integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==


### PR DESCRIPTION
Yargs v16 made some changes that broke bundling. Using `const yargs = require('yargs')` caused yargs to be excluded from the bundle, breaking the image until it was installed through `yarn`. That's not a permanent fix, creating extra files.

This uses the CJS version of yargs provided in the package, and seems to both a) work and b) inline all the yargs/y18n code.